### PR TITLE
Adding missing member variable doc comment.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,61 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.4', '8.0', '8.1']
-        moodle-branch: ['MOODLE_401_STABLE']
-        database: [pgsql, mariadb]
+        include:
+          - php: 8.2
+            moodle-branch: MOODLE_403_STABLE
+            database: pgsql
+          - php: 8.2
+            moodle-branch: MOODLE_403_STABLE
+            database: mariadb
+          - php: 8.1
+            moodle-branch: MOODLE_403_STABLE
+            database: pgsql
+          - php: 8.1
+            moodle-branch: MOODLE_403_STABLE
+            database: mariadb
+          - php: 8.0
+            moodle-branch: MOODLE_403_STABLE
+            database: pgsql
+          - php: 8.0
+            moodle-branch: MOODLE_403_STABLE
+            database: mariadb
+          - php: 8.2
+            moodle-branch: MOODLE_402_STABLE
+            database: pgsql
+          - php: 8.2
+            moodle-branch: MOODLE_402_STABLE
+            database: mariadb
+          - php: 8.1
+            moodle-branch: MOODLE_402_STABLE
+            database: pgsql
+          - php: 8.1
+            moodle-branch: MOODLE_402_STABLE
+            database: mariadb
+          - php: 8.0
+            moodle-branch: MOODLE_402_STABLE
+            database: pgsql
+          - php: 8.0
+            moodle-branch: MOODLE_402_STABLE
+            database: mariadb
+          - php: 8.1
+            moodle-branch: MOODLE_401_STABLE
+            database: pgsql
+          - php: 8.1
+            moodle-branch: MOODLE_401_STABLE
+            database: mariadb
+          - php: 8.0
+            moodle-branch: MOODLE_401_STABLE
+            database: pgsql
+          - php: 8.0
+            moodle-branch: MOODLE_401_STABLE
+            database: mariadb
+          - php: 7.4
+            moodle-branch: MOODLE_401_STABLE
+            database: pgsql
+          - php: 7.4
+            moodle-branch: MOODLE_401_STABLE
+            database: mariadb
 
     steps:
       - name: Check out repository code
@@ -69,11 +121,6 @@ jobs:
       - name: PHP Lint
         if: ${{ !cancelled() }}
         run: moodle-plugin-ci phplint
-
-      - name: PHP Copy/Paste Detector
-        continue-on-error: true # This step will show errors but will not fail
-        if: ${{ !cancelled() }}
-        run: moodle-plugin-ci phpcpd
 
       - name: PHP Mess Detector
         continue-on-error: true # This step will show errors but will not fail

--- a/export_table.php
+++ b/export_table.php
@@ -41,14 +41,14 @@ class quiz_exportattemptscsv_table extends quiz_attempts_report_table {
 
     /**
      * Constructor
-     * @param object $quiz
-     * @param context $context
-     * @param string $qmsubselect
-     * @param quiz_exportattemptscsv_options $options
-     * @param \core\dml\sql_join $groupstudentsjoins
-     * @param \core\dml\sql_join $studentsjoins
-     * @param array $questions
-     * @param moodle_url $reporturl
+     * @param object $quiz the quiz settings
+     * @param context $context the context object
+     * @param string $qmsubselect HTML fragment to select the first/best/last attempt, if appropriate
+     * @param quiz_exportattemptscsv_options $options the quiz export attemts csv settings
+     * @param \core\dml\sql_join $groupstudentsjoins to indicate a set of groups
+     * @param \core\dml\sql_join $studentsjoins to indicate a set of users
+     * @param array $questions an array of question objects
+     * @param moodle_url $reporturl the URL of this report
      */
     public function __construct($quiz, $context, $qmsubselect,
                                 quiz_exportattemptscsv_options $options,


### PR DESCRIPTION
This will turn all tests to green (and include ones for Moodle 4.3 and Moodle 4.2, too) and make the "Code prechecks" part in the plugins database completely flawless.